### PR TITLE
feat(coingecko): add endpoint for token market chart

### DIFF
--- a/packages/coingecko/recipes/endpoints/tokenMarketChart/e2e.json
+++ b/packages/coingecko/recipes/endpoints/tokenMarketChart/e2e.json
@@ -1,0 +1,14 @@
+[
+  {
+    "api": "ens/testnet/coingecko.eth"
+  },
+  {
+    "query": "./schema.graphql",
+    "variables": {
+      "id": "ethereum",
+      "contract_address": "0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce",
+      "vs_currency": "usd",
+      "days": 7
+    }
+  }
+]

--- a/packages/coingecko/recipes/endpoints/tokenMarketChart/schema.graphql
+++ b/packages/coingecko/recipes/endpoints/tokenMarketChart/schema.graphql
@@ -1,0 +1,8 @@
+query TokenMarketChart(
+  $id: String!
+  $contract_address: String!
+  $vs_currency: String!
+  $days: Int!
+) {
+  tokenMarketChart(id: $id, contract_address: $contract_address, vs_currency: $vs_currency, days: $days)
+}

--- a/packages/coingecko/src/__tests__/e2e/types.ts
+++ b/packages/coingecko/src/__tests__/e2e/types.ts
@@ -1,5 +1,11 @@
+import { TokenMarketChart } from "../../query/w3";
+
 export type Ping = {
   ping: {
     gecko_says: string;
   };
+};
+
+export type TokenMarketChartResult = {
+  tokenMarketChart: TokenMarketChart;
 };

--- a/packages/coingecko/src/commons/schema.graphql
+++ b/packages/coingecko/src/commons/schema.graphql
@@ -1,4 +1,22 @@
 """
+Common Types
+"""
+type TimestampPricePair {
+  timestamp: BigInt!
+  price: String! # Float64
+}
+
+type TimestampMarketCapPair {
+  timestamp: BigInt!
+  market_cap: String! # Float 64
+}
+
+type TimestampVolumePair {
+  timestamp: BigInt!
+  volume: String! # Float64
+}
+
+"""
 Ping Response https://api.coingecko.com/api/v3/ping
 """
 type Ping {
@@ -269,4 +287,13 @@ type TokenInfoTickerMarket {
   name: String!
   identifier: String!
   has_trading_incentive: Boolean!
+}
+
+"""
+TokenMarketChart https://api.coingecko.com/api/v3/coins/{id}/contract/{contract_address}/market_chart
+"""
+type TokenMarketChart {
+  prices: [TimestampPricePair!]!
+  market_caps: [TimestampMarketCapPair!]!
+  total_volumes: [TimestampVolumePair!]!
 }

--- a/packages/coingecko/src/commons/schema.graphql
+++ b/packages/coingecko/src/commons/schema.graphql
@@ -190,7 +190,7 @@ type TokenInfoMarketData {
   price_change_percentage_60d: String!
   price_change_percentage_200d: String!
   price_change_percentage_1y: String!
-  market_cap_change_24h: Int!
+  market_cap_change_24h: String! # Float64
   market_cap_change_percentage_24h: String!
   price_change_24h_in_currency: [TokenInfoCurrencyPricePair!]!
   price_change_percentage_1h_in_currency: [TokenInfoCurrencyPercentagePair!]!

--- a/packages/coingecko/src/query/index.ts
+++ b/packages/coingecko/src/query/index.ts
@@ -5,6 +5,7 @@ import { simpleTokenPrice } from "./routes/simpleTokenPrice";
 import { coinsList } from "./routes/coinsList";
 import { supportedVSCurrencies } from "./routes/supportedVSCurrencies";
 import { tokenInfo } from "./routes/tokenInfo";
+import { tokenMarketChart } from "./routes/tokenMarketChart";
 
 export {
   ping,
@@ -14,4 +15,5 @@ export {
   simplePrice,
   simpleTokenPrice,
   tokenInfo,
+  tokenMarketChart,
 };

--- a/packages/coingecko/src/query/routes/tokenInfo.ts
+++ b/packages/coingecko/src/query/routes/tokenInfo.ts
@@ -195,7 +195,7 @@ function createMarketData(json: JSON.Obj): TokenInfoMarketData {
     price_change_percentage_60d: getStringProperty(json, "price_change_percentage_60d"),
     price_change_percentage_200d: getStringProperty(json, "price_change_percentage_200d"),
     price_change_percentage_1y: getStringProperty(json, "price_change_percentage_1y"),
-    market_cap_change_24h: getIntegerProperty<i32>(json, "market_cap_change_24h"),
+    market_cap_change_24h: getStringProperty(json, "market_cap_change_24h"),
     market_cap_change_percentage_24h: getStringProperty(json, "market_cap_change_percentage_24h"),
     price_change_24h_in_currency: priceChange24h,
     price_change_percentage_1h_in_currency: priceChangePercent1h,

--- a/packages/coingecko/src/query/routes/tokenMarketChart.ts
+++ b/packages/coingecko/src/query/routes/tokenMarketChart.ts
@@ -37,7 +37,7 @@ export function tokenMarketChart(input: Input_tokenMarketChart): TokenMarketChar
   });
 
   if (!response || response.status !== 200 || !response.body) {
-    throw new Error(response.statusText);
+    throw new Error(response ? response.statusText : "response should be defined");
   }
 
   const obj = <JSON.Obj>JSON.parse(response.body);

--- a/packages/coingecko/src/query/routes/tokenMarketChart.ts
+++ b/packages/coingecko/src/query/routes/tokenMarketChart.ts
@@ -37,7 +37,7 @@ export function tokenMarketChart(input: Input_tokenMarketChart): TokenMarketChar
   });
 
   if (!response || response.status !== 200 || !response.body) {
-    throw Error(response.statusText);
+    throw new Error(response.statusText);
   }
 
   const obj = <JSON.Obj>JSON.parse(response.body);

--- a/packages/coingecko/src/query/routes/tokenMarketChart.ts
+++ b/packages/coingecko/src/query/routes/tokenMarketChart.ts
@@ -5,7 +5,6 @@ import {
   HTTP_Query,
   HTTP_ResponseType,
   HTTP_UrlParam,
-  Console_Query,
   Input_tokenMarketChart,
   TimestampMarketCapPair,
   TimestampPricePair,

--- a/packages/coingecko/src/query/routes/tokenMarketChart.ts
+++ b/packages/coingecko/src/query/routes/tokenMarketChart.ts
@@ -1,0 +1,93 @@
+import { JSON } from "@web3api/assemblyscript-json";
+import { BigInt } from "as-bigint";
+import { COINGECKO_API_URL } from "../config";
+import {
+  HTTP_Query,
+  HTTP_ResponseType,
+  HTTP_UrlParam,
+  Console_Query,
+  Input_tokenMarketChart,
+  TimestampMarketCapPair,
+  TimestampPricePair,
+  TimestampVolumePair,
+  TokenMarketChart,
+} from "../w3";
+
+export function tokenMarketChart(input: Input_tokenMarketChart): TokenMarketChart {
+  const url =
+    COINGECKO_API_URL +
+    "/coins/" +
+    input.id +
+    "/contract/" +
+    input.contract_address +
+    "/market_chart";
+
+  const urlParams: Array<HTTP_UrlParam> = [
+    { key: "vs_currency", value: input.vs_currency },
+    { key: "days", value: input.days.toString() },
+  ];
+
+  const response = HTTP_Query.get({
+    url,
+    request: {
+      headers: [],
+      urlParams,
+      body: "",
+      responseType: HTTP_ResponseType.TEXT,
+    },
+  });
+
+  if (!response || response.status !== 200 || !response.body) {
+    throw Error(response.statusText);
+  }
+
+  const obj = <JSON.Obj>JSON.parse(response.body);
+
+  // prices
+  const pricesArray = obj.getArr("prices");
+  if (pricesArray === null) {
+    throw new Error("error in response: prices should be an array");
+  }
+
+  const prices = pricesArray._arr.map<TimestampPricePair>((item) => {
+    const priceItem = item as JSON.Arr;
+    return {
+      timestamp: BigInt.fromString(priceItem._arr[0].toString()),
+      price: priceItem._arr[1].toString(),
+    };
+  });
+
+  // market_capstotalVolumeItem._arr[0] as JSON.Integer
+  const marketCapsArray = obj.getArr("market_caps");
+  if (marketCapsArray === null) {
+    throw new Error("error in response: market_caps should be an array");
+  }
+
+  const marketCaps = marketCapsArray._arr.map<TimestampMarketCapPair>((item) => {
+    const marketCapItem = item as JSON.Arr;
+    return {
+      timestamp: BigInt.fromString(marketCapItem._arr[0].toString()),
+      market_cap: marketCapItem._arr[1].toString(),
+    };
+  });
+
+  // total_volumes
+  const totalVolumesArray = obj.getArr("total_volumes");
+  if (totalVolumesArray === null) {
+    throw new Error("error in response: total_volumes should not be an array");
+  }
+
+  const totalVolumes = totalVolumesArray._arr.map<TimestampVolumePair>((item) => {
+    const totalVolumeItem = item as JSON.Arr;
+    return {
+      timestamp: BigInt.fromString(totalVolumeItem._arr[0].toString()),
+      volume: totalVolumeItem._arr[1].toString(),
+    };
+  });
+
+  return {
+    prices,
+    market_caps: marketCaps,
+    total_volumes: totalVolumes,
+  };
+}

--- a/packages/coingecko/src/query/schema.graphql
+++ b/packages/coingecko/src/query/schema.graphql
@@ -1,5 +1,14 @@
 #import { Query } into HTTP from "w3://ens/http.web3api.eth"
-#import { Ping, CoinsList, CoinsMarkets, SimplePrice, SimpleTokenPrice, TokenInfo } from "../commons/schema.graphql"
+#import { Query } into Console from "w3://ens/js-logger.web3api.eth"
+#import {
+  Ping,
+  CoinsList,
+  CoinsMarkets,
+  SimplePrice,
+  SimpleTokenPrice,
+  TokenInfo,
+  TokenMarketChart
+} from "../commons/schema.graphql"
 
 type Query {
   ping: Ping!
@@ -42,4 +51,11 @@ type Query {
     id: String!
     contract_address: String!
   ): TokenInfo!
+
+  tokenMarketChart(
+      id: String!
+      contract_address: String!
+      vs_currency: String!
+      days: Int!
+  ): TokenMarketChart!
 }

--- a/packages/coingecko/src/query/schema.graphql
+++ b/packages/coingecko/src/query/schema.graphql
@@ -1,5 +1,4 @@
 #import { Query } into HTTP from "w3://ens/http.web3api.eth"
-#import { Query } into Console from "w3://ens/js-logger.web3api.eth"
 #import {
   Ping,
   CoinsList,


### PR DESCRIPTION
Hey there,

This PR adds endpoint for token market chart at `/coins/{id}/contract/{contract_address}/market_chart`.

Closes #25 